### PR TITLE
Añadido CI de Docker para realizar Build y Push de imagenes

### DIFF
--- a/.github/workflows/docker_ci.yaml
+++ b/.github/workflows/docker_ci.yaml
@@ -1,0 +1,27 @@
+name: Docker CI
+
+on:
+  workflow_run:
+    workflows: [Rust CI]
+    types: [completed]
+    branches: [staging, production]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    environment:
+      name: ${{ github.ref_name }}
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build Docker Image
+      run: docker build . --file Dockerfile --tag ${{ vars.DOCKER_ACCOUNT }}/${{ vars.DOCKER_REPOSITORY }}:${{ env.DOCKER_TAG_ENV }}-latest
+  push:
+    runs-on: ubuntu-latest
+    environment:
+      name: ${{ github.ref_name }}
+    steps:
+    - uses: actions/ckeckout@v4
+    - name: Push Docker Image
+      run: |
+          docker login -u ${{ vars.DOCKER_ACCOUNT }} -p ${{ secrets.DOCKER_HUB_TOKEN }}
+          docker push ${{ vars.DOCKER_ACCOUNT }}/${{ vars.DOCKER_REPOSITORY }}:${{ env.DOCKER_TAG_ENV }}-latest

--- a/.github/workflows/docker_ci.yaml
+++ b/.github/workflows/docker_ci.yaml
@@ -9,19 +9,11 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    environment:
-      name: ${{ github.ref_name }}
     steps:
     - uses: actions/checkout@v4
     - name: Build Docker Image
-      run: docker build . --file Dockerfile --tag ${{ vars.DOCKER_ACCOUNT }}/${{ vars.DOCKER_REPOSITORY }}:${{ env.DOCKER_TAG_ENV }}-latest
-  push:
-    runs-on: ubuntu-latest
-    environment:
-      name: ${{ github.ref_name }}
-    steps:
-    - uses: actions/ckeckout@v4
+      run: docker build . --file Dockerfile --tag ${{ vars.DOCKER_ACCOUNT }}/${{ vars.DOCKER_REPOSITORY }}:${{ github.ref_name }}-latest
     - name: Push Docker Image
       run: |
           docker login -u ${{ vars.DOCKER_ACCOUNT }} -p ${{ secrets.DOCKER_HUB_TOKEN }}
-          docker push ${{ vars.DOCKER_ACCOUNT }}/${{ vars.DOCKER_REPOSITORY }}:${{ env.DOCKER_TAG_ENV }}-latest
+          docker push ${{ vars.DOCKER_ACCOUNT }}/${{ vars.DOCKER_REPOSITORY }}:${{ github.ref_name }}-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,5 @@ RUN apt-get update -y \
 
 WORKDIR /app
 COPY --from=builder /app/target/release/byte_genius_hosting byte_genius_hosting
-COPY configuration configuration
 ENV APP_ENVIRONMENT=production
 ENTRYPOINT ["./byte_genius_hosting"]


### PR DESCRIPTION
## Describe el pull request

Se añade el workflow de "Docker CI" para automatizar el build y push de la imagen del repositorio cuando se realiza un merge a staging y production. El build de la imagen se realiza con el tag correspondiente a la rama actual

## Describe los cambios realizados

- Se añadió el yaml con el workflow del CI
- Se modificó el Dockerfile por un error a la hora de buildear

## Checklist
- [x] Realicé una revisión sobre el código
- [x] Realicé testeos de forma local
