### PR TITLE
Añadido endpoints start y stop server

### DIFF
--- a/src/routes/dashboard.rs
+++ b/src/routes/dashboard.rs
@@ -1,0 +1,46 @@
+use actix_web::{HttpResponse, Responder, web::Json};
+use serde;
+use std::process::{Command, Output};
+
+#[derive(serde::Deserialize)]
+pub struct ServerInfo {
+    username: String,
+}
+
+pub async fn start(json: Json<ServerInfo>) -> impl Responder {
+    let output = execute_command(&json.username, 1);
+
+    if output.status.success() {
+        HttpResponse::Ok()
+            .body("Servidor abierto! Espere unos minutos hasta que se inicie por completo")
+    } else {
+        let stdout = String::from_utf8(output.stderr).unwrap();
+
+        HttpResponse::InternalServerError().body(stdout)
+    }
+}
+
+pub async fn stop(json: Json<ServerInfo>) -> impl Responder {
+    let output = execute_command(&json.username, 0);
+
+    if output.status.success() {
+        HttpResponse::Ok().body("Servidor cerrado!")
+    } else {
+        let stdout = String::from_utf8(output.stderr).unwrap();
+
+        HttpResponse::InternalServerError().body(stdout)
+    }
+}
+
+fn execute_command(username: &str, replica: u8) -> Output {
+    Command::new("kubectl")
+        .args([
+            "patch",
+            "deployment",
+            &format!("minecraft-{}", username.to_lowercase()),
+            "-p",
+            &format!("{{\"spec\":{{\"replicas\":{}}}}}", replica),
+        ])
+        .output()
+        .expect("Error al ejecutar el comando")
+}

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -1,5 +1,7 @@
+mod dashboard;
 mod deploy;
 mod health_check;
 
+pub use dashboard::*;
 pub use deploy::*;
 pub use health_check::*;

--- a/src/startup.rs
+++ b/src/startup.rs
@@ -10,6 +10,8 @@ pub fn run(listener: TcpListener) -> Result<Server, std::io::Error> {
             .wrap(TracingLogger::default())
             .route("/health_check", web::get().to(healt_check))
             .route("/server", web::post().to(deploy_chart))
+            .route("/dashboard/start", web::get().to(start))
+            .route("/dashboard/stop", web::get().to(stop))
     })
     .listen(listener)?
     .run();


### PR DESCRIPTION
## Describe el pull request

Se añadieron los endpoints /dashboard/start y /dashboard/stop para parar los servidores en deploy

## Checklist
- [x] Realicé una revisión sobre el código
- [x] Realicé testeos de forma local
