### PR TITLE
Feature/dashboard status

### DIFF
--- a/src/routes/dashboard.rs
+++ b/src/routes/dashboard.rs
@@ -102,8 +102,8 @@ pub async fn status(json: Json<ServerInfo>) -> impl Responder {
                 .unwrap(),
         };
 
-        status.cpu = status.cpu / 10;
-        status.ram = status.ram * 1.04858_f64;
+        status.cpu /= 10;
+        status.ram *= 1.04858_f64;
 
         HttpResponse::Ok().json(status)
     } else {

--- a/src/routes/dashboard.rs
+++ b/src/routes/dashboard.rs
@@ -7,6 +7,12 @@ pub struct ServerInfo {
     id: String,
 }
 
+#[derive(serde::Serialize, Debug)]
+pub struct ServerStatus {
+    cpu: u64,
+    ram: f64,
+}
+
 pub async fn start(json: Json<ServerInfo>) -> impl Responder {
     let output = execute_command(&json.id, 1);
 
@@ -43,4 +49,66 @@ fn execute_command(id: &str, replica: u8) -> Output {
         ])
         .output()
         .expect("Error al ejecutar el comando")
+}
+
+pub async fn status(json: Json<ServerInfo>) -> impl Responder {
+    let output = Command::new("kubectl")
+        .args([
+            "get",
+            "pods",
+            "-l",
+            &format!("app=minecraft-{}", json.id),
+            "-o",
+            "jsonpath=\"{.items[0].metadata.name}\"",
+        ])
+        .output()
+        .expect("Error al ejecutar el comando kubectl get pods");
+
+    if !(output.status.success()) {
+        let stdout = String::from_utf8(output.stderr).unwrap();
+
+        return HttpResponse::InternalServerError().body(stdout);
+    }
+
+    let pod_name = String::from_utf8(output.stdout).unwrap();
+
+    let pod_str = pod_name
+        .strip_suffix("\"")
+        .unwrap()
+        .strip_prefix("\"")
+        .unwrap();
+
+    let output = Command::new("kubectl")
+        .args(["top", "pods", pod_str])
+        .output()
+        .expect("Error al ejecutar el comando kubectl top");
+
+    if output.status.success() {
+        let stdout = String::from_utf8(output.stdout).unwrap();
+        let usage_str = stdout.split("\n").collect::<Vec<&str>>()[1];
+
+        let resouces_usage: Vec<&str> = usage_str.split_whitespace().collect();
+
+        let mut status = ServerStatus {
+            cpu: resouces_usage[1]
+                .strip_suffix("m")
+                .unwrap()
+                .parse()
+                .unwrap(),
+            ram: resouces_usage[2]
+                .strip_suffix("Mi")
+                .unwrap()
+                .parse()
+                .unwrap(),
+        };
+
+        status.cpu = status.cpu / 10;
+        status.ram = status.ram * 1.04858_f64;
+
+        HttpResponse::Ok().json(status)
+    } else {
+        let stdout = String::from_utf8(output.stderr).unwrap();
+
+        HttpResponse::InternalServerError().body(stdout)
+    }
 }

--- a/src/startup.rs
+++ b/src/startup.rs
@@ -12,6 +12,7 @@ pub fn run(listener: TcpListener) -> Result<Server, std::io::Error> {
             .route("/server", web::post().to(deploy_chart))
             .route("/dashboard/start", web::get().to(start))
             .route("/dashboard/stop", web::get().to(stop))
+            .route("/dashboard/status", web::get().to(status))
     })
     .listen(listener)?
     .run();


### PR DESCRIPTION
## Describe el pull request

Se añadió el endpoint GET /dashboard/status para conseguir información sobre el status del servidor con el id dado por JSON en la key "id". El servidor en caso de respuesta de 200, va a devolver un JSON con 2 key values, siendo cpu la cantidad en % y ram la cantidad usada en MB.

## Checklist
- [x] Realicé una revisión sobre el código
- [x] Realicé testeos de forma local
