### PR TITLE
Added specific namespace to chart install

### DIFF
--- a/src/routes/deploy.rs
+++ b/src/routes/deploy.rs
@@ -16,6 +16,8 @@ pub async fn deploy_chart(deploy_info: Json<DeployInfo>) -> impl Responder {
             "install",
             &format!("minecraft-{}", deploy_info.id.to_lowercase()),
             "mc-charts/minecraft",
+            "--namespace",
+            "hosting",
             "--set",
             &format!("minecraftServer.eula=true,minecraftServer.Difficulty=hard,minecraftServer.memory={}M,resources.limits.cpu={},resources.limits.memory={}M",
                 (deploy_info.ram * 1024),


### PR DESCRIPTION
## Describe el pull request

Se cambió el namespace donde se instalan los charts de helm. Ahora se instalan en el namespace "hosting"

## Checklist
- [x] Realicé una revisión sobre el código
- [x] Realicé testeos de forma local
